### PR TITLE
Issue/field sortable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maykin-ui/admin-ui",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maykin-ui/admin-ui",
-      "version": "0.0.45",
+      "version": "0.0.46",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.26.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maykin-ui/admin-ui",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "description": "",
   "scripts": {
     "create-component": "./bin/create_component.sh",

--- a/src/components/data/attributetable/attributetable.tsx
+++ b/src/components/data/attributetable/attributetable.tsx
@@ -5,8 +5,8 @@ import {
   Field,
   SerializedFormData,
   TypedField,
+  fields2TypedFields,
   string2Title,
-  typedFieldByFields,
   useIntl,
 } from "../../../lib";
 import { Button } from "../../button";
@@ -72,7 +72,7 @@ export const AttributeTable = <T extends object = object>({
 }: AttributeTableProps<T>) => {
   const intl = useIntl();
   const [isFormOpenState, setIsFormOpenState] = useState(false);
-  const typedFields = typedFieldByFields(fields, [object], { editable });
+  const typedFields = fields2TypedFields(fields, [object], { editable });
   const _editable = Boolean(typedFields.find((f) => f.editable));
 
   const _labelCancel = labelCancel

--- a/src/components/data/datagrid/datagrid.scss
+++ b/src/components/data/datagrid/datagrid.scss
@@ -118,8 +118,9 @@
   }
 
   &__cell--checkbox,
-  &__cell--type-null,
   &__cell--type-boolean,
+  &__cell--type-jsx,
+  &__cell--type-null,
   &__cell--type-number {
     text-align: end;
     width: 0; // TODO: Possibly 1px for WebKit (Safari)?

--- a/src/components/data/datagrid/datagrid.stories.tsx
+++ b/src/components/data/datagrid/datagrid.stories.tsx
@@ -222,6 +222,52 @@ export const Sortable: Story = {
 };
 
 /**
+ * pass `false` to `field.sortable` to exclude field from sorting.
+ */
+export const FieldExcludedFromSortable: Story = {
+  args: {
+    fields: [
+      "name",
+      "category",
+      "price",
+      "stock",
+      "isAvailable",
+      { name: "action", type: "jsx", sortable: false },
+    ],
+    objectList: FIXTURE_PRODUCTS.map((item) => ({
+      ...item,
+      action: (
+        <Button pad="h" variant="secondary">
+          Buy!
+        </Button>
+      ),
+    })),
+    sort: true,
+  },
+  // Don't set argTypes.onSort as it will result in a onSort prop being passed
+  // preventing built-in sort (external sorting is expected in such cases).
+};
+
+/**
+ * pass `true` to `field.sortable` to explicitly allow sorting on field.
+ */
+export const SingleFieldSortable: Story = {
+  args: {
+    fields: [
+      { name: "id", type: "number", sortable: true },
+      "name",
+      "category",
+      "price",
+      "stock",
+      "isAvailable",
+    ],
+    objectList: FIXTURE_PRODUCTS,
+  },
+  // Don't set argTypes.onSort as it will result in a onSort prop being passed
+  // preventing built-in sort (external sorting is expected in such cases).
+};
+
+/**
  * pass a `string` to `sort` (optionally prefix by `-` to invert sorting) prop
  * to set a predefined order.
  */

--- a/src/components/data/datagrid/datagrid.tsx
+++ b/src/components/data/datagrid/datagrid.tsx
@@ -16,8 +16,8 @@ import {
   SerializedFormData,
   TypedField,
   TypedSerializedFormData,
+  fields2TypedFields,
   filterDataArray,
-  typedFieldByFields,
 } from "../../../lib";
 import { sortDataArray } from "../../../lib";
 import { BadgeProps } from "../../badge";
@@ -482,7 +482,7 @@ export const DataGrid = <T extends object = object, F extends object = T>(
   // Convert `Array<Field|TypedField>` to `TypedField[]`.
   const typedFields = useMemo(
     () =>
-      typedFieldByFields(fieldsState, objectList, {
+      fields2TypedFields(fieldsState, objectList, {
         editable: Boolean(editable),
         filterable: Boolean(filterable),
       }).filter((f) => !(urlFields || []).includes(String(f.name))),

--- a/src/components/data/datagrid/datagrid.tsx
+++ b/src/components/data/datagrid/datagrid.tsx
@@ -485,6 +485,7 @@ export const DataGrid = <T extends object = object, F extends object = T>(
       fields2TypedFields(fieldsState, objectList, {
         editable: Boolean(editable),
         filterable: Boolean(filterable),
+        sortable: Boolean(sort),
       }).filter((f) => !(urlFields || []).includes(String(f.name))),
     [fieldsState, objectList, urlFields, editable, filterable],
   );

--- a/src/components/data/datagrid/datagridheadingcell.tsx
+++ b/src/components/data/datagrid/datagridheadingcell.tsx
@@ -25,10 +25,7 @@ export const DataGridHeadingCell = <
   children,
   field,
 }: DataGridHeadingCellProps<T, F>) => {
-  const { sortField, sortable, sortDirection, onSort } = useDataGridContext<
-    T,
-    F
-  >();
+  const { sortField, sortDirection, onSort } = useDataGridContext<T, F>();
   const isSorted = sortField === field.name;
 
   return (
@@ -39,7 +36,7 @@ export const DataGridHeadingCell = <
       role="columnheader"
       style={field.width ? { width: field.width } : {}}
     >
-      {sortable ? (
+      {field.sortable ? (
         <Button
           active={isSorted}
           align="space-between"

--- a/src/lib/data/field.ts
+++ b/src/lib/data/field.ts
@@ -99,7 +99,7 @@ export type FieldSet<T extends object = object> = [
  * @param objectList
  * @param base
  */
-export const typedFieldByFields = <T extends object>(
+export const fields2TypedFields = <T extends object>(
   optionallyTypedFields: Array<Field<T> | TypedField<T>>,
   objectList: T[],
   base?: Partial<TypedField<T>>,

--- a/src/lib/data/field.ts
+++ b/src/lib/data/field.ts
@@ -43,6 +43,9 @@ export type TypedField<T extends object = object> = {
   /** The value for this field's filter. */
   filterValue?: string | number;
 
+  /** Used by DataGrid to determine whether the field should be sortable. */
+  sortable?: boolean;
+
   /**
    * The "lookup" (dot separated) to use for this field while filtering (e.g.
    * "._expand.zaaktype.omschrijving").
@@ -69,7 +72,8 @@ export type FieldType =
   | "daterange"
   | "null"
   | "number"
-  | "string";
+  | "string"
+  | "jsx";
 
 /** A Django-admin like field_options definition. */
 export type FieldOptions<T extends object = object> = {


### PR DESCRIPTION
Allows a TypedField to specify whether the field should be sortable (for DataGrid usage), this overrides the DataGrid option.