### PR TITLE
Issue/open beheer #116

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -6,6 +6,11 @@
   flex-direction: column;
   //overflow: clip;  // Turned off for now to allow DatePicker to overflow Card and Modal.
   width: 100%;
+  border: unset;
+
+  &--border {
+    border: 1px solid var(--typography-color-border);
+  }
 
   &--direction--column {
     flex-direction: column;

--- a/src/components/card/card.stories.tsx
+++ b/src/components/card/card.stories.tsx
@@ -51,3 +51,15 @@ export const CardWithControls: Story = {
     ),
   },
 };
+
+export const CardWithBorder: Story = {
+  args: {
+    border: true,
+    title: "Card with border",
+    children: (
+      <Body>
+        <P>The quick brown fox jumps over the lazy dog.</P>
+      </Body>
+    ),
+  },
+};

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 import { ButtonProps } from "../button";
 import { Toolbar, ToolbarItem } from "../toolbar";
-import { Body, H2 } from "../typography";
+import { Body, H3 } from "../typography";
 import "./card.scss";
 
 export type CardProps = React.PropsWithChildren<
@@ -35,6 +35,9 @@ export type CardProps = React.PropsWithChildren<
 
   /** A title for the card. */
   title?: string | React.ReactNode;
+
+  /** asTitle, a component to use as the title. */
+  asTitle?: React.ElementType;
 };
 
 /**
@@ -50,6 +53,7 @@ export const Card: React.FC<CardProps> = ({
   justify,
   fullHeight = false,
   title,
+  asTitle: TitleComponent = H3,
   ...props
 }) => {
   // Controls is renamed to actions.
@@ -74,7 +78,11 @@ export const Card: React.FC<CardProps> = ({
       {(actions.length || title) && (
         <div className="mykn-card__header">
           <Body fullHeight>
-            {typeof title === "string" ? <H2>{title}</H2> : title}
+            {typeof title === "string" ? (
+              <TitleComponent>{title}</TitleComponent>
+            ) : (
+              title
+            )}
           </Body>
           {Boolean(actions?.length) && (
             <Toolbar

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -7,7 +7,7 @@ import { Body, H3 } from "../typography";
 import "./card.scss";
 
 export type CardProps = React.PropsWithChildren<
-  React.HTMLAttributes<HTMLDivElement>
+  Omit<React.HTMLAttributes<HTMLDivElement>, "title">
 > & {
   /** Buttons to use in the header. */
   actions?: ToolbarItem[];

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -6,7 +6,9 @@ import { Toolbar, ToolbarItem } from "../toolbar";
 import { Body, H3 } from "../typography";
 import "./card.scss";
 
-export type CardProps = React.PropsWithChildren<{
+export type CardProps = React.PropsWithChildren<
+  React.HTMLAttributes<HTMLDivElement>
+> & {
   /** Buttons to use in the header. */
   actions?: ToolbarItem[];
 
@@ -33,7 +35,7 @@ export type CardProps = React.PropsWithChildren<{
 
   /** A title for the card. */
   title?: string | React.ReactNode;
-}>;
+};
 
 /**
  * Card component
@@ -41,6 +43,7 @@ export type CardProps = React.PropsWithChildren<{
 export const Card: React.FC<CardProps> = ({
   controls = [],
   border = false,
+  className,
   actions = controls,
   children,
   direction = "column",
@@ -56,12 +59,16 @@ export const Card: React.FC<CardProps> = ({
 
   return (
     <div
-      className={clsx("mykn-card", {
-        "mykn-card--full-height": fullHeight,
-        "mykn-card--border": border,
-        [`mykn-card--direction-${direction}`]: direction,
-        [`mykn-card--justify-${justify}`]: justify,
-      })}
+      className={clsx(
+        "mykn-card",
+        {
+          "mykn-card--full-height": fullHeight,
+          "mykn-card--border": border,
+          [`mykn-card--direction-${direction}`]: direction,
+          [`mykn-card--justify-${justify}`]: justify,
+        },
+        className,
+      )}
       {...props}
     >
       {(actions.length || title) && (

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 import { ButtonProps } from "../button";
 import { Toolbar, ToolbarItem } from "../toolbar";
-import { Body, H3 } from "../typography";
+import { Body, H2 } from "../typography";
 import "./card.scss";
 
 export type CardProps = React.PropsWithChildren<
@@ -74,7 +74,7 @@ export const Card: React.FC<CardProps> = ({
       {(actions.length || title) && (
         <div className="mykn-card__header">
           <Body fullHeight>
-            {typeof title === "string" ? <H3>{title}</H3> : title}
+            {typeof title === "string" ? <H2>{title}</H2> : title}
           </Body>
           {Boolean(actions?.length) && (
             <Toolbar

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -36,8 +36,8 @@ export type CardProps = React.PropsWithChildren<
   /** A title for the card. */
   title?: string | React.ReactNode;
 
-  /** asTitle, a component to use as the title. */
-  asTitle?: React.ElementType;
+  /** titleAs, a component to use as the title. */
+  titleAs?: React.ElementType;
 };
 
 /**
@@ -53,7 +53,7 @@ export const Card: React.FC<CardProps> = ({
   justify,
   fullHeight = false,
   title,
-  asTitle: TitleComponent = H3,
+  titleAs: TitleComponent = H3,
   ...props
 }) => {
   // Controls is renamed to actions.

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -10,6 +10,9 @@ export type CardProps = React.PropsWithChildren<{
   /** Buttons to use in the header. */
   actions?: ToolbarItem[];
 
+  /** Border around the card. */
+  border?: boolean;
+
   /** @deprecated: REMOVE IN 3.0 - Renamed to actions. */
   controls?: ButtonProps[];
 
@@ -37,6 +40,7 @@ export type CardProps = React.PropsWithChildren<{
  */
 export const Card: React.FC<CardProps> = ({
   controls = [],
+  border = false,
   actions = controls,
   children,
   direction = "column",
@@ -54,6 +58,7 @@ export const Card: React.FC<CardProps> = ({
     <div
       className={clsx("mykn-card", {
         "mykn-card--full-height": fullHeight,
+        "mykn-card--border": border,
         [`mykn-card--direction-${direction}`]: direction,
         [`mykn-card--justify-${justify}`]: justify,
       })}

--- a/src/components/layout/grid/grid.scss
+++ b/src/components/layout/grid/grid.scss
@@ -23,15 +23,15 @@
   }
 
   &--gutter-true {
-    gap: var(--spacing-xs-v) var(--spacing-xs-h);
+    gap: var(--spacing-s-v) var(--spacing-s-h);
   }
 
   &--gutter-v {
-    gap: var(--spacing-xs-v) 0;
+    gap: var(--spacing-s-v) 0;
   }
 
   &--spacing-xs-h {
-    gap: 0 var(--spacing-xs-h);
+    gap: 0 var(--spacing-s-h);
   }
 
   &--full-height {
@@ -52,15 +52,15 @@
     }
 
     &--gutter-true {
-      gap: var(--spacing-xs-v) var(--spacing-xs-h);
+      gap: var(--spacing-s-v) var(--spacing-s-h);
     }
 
     &--spacing-xs-h {
-      gap: 0 var(--spacing-xs-h-desktop);
+      gap: 0 var(--spacing-s-h-desktop);
     }
 
     &--gutter-v {
-      gap: var(--spacing-xs-v) 0;
+      gap: var(--spacing-s-v) 0;
     }
 
     @for $i from 1 through 12 {

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -129,7 +129,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 title={expandedState ? _labelCollapse : _labelExpand}
                 size="xxs"
                 pad={false}
-                rounded
                 square
                 variant="outline"
                 onClick={handleClick}

--- a/src/components/typography/li/li.scss
+++ b/src/components/typography/li/li.scss
@@ -1,4 +1,5 @@
 .mykn-li {
+  margin: 0;
   color: var(--typography-color-body);
   font-family: var(--typography-font-family-body);
   font-size: var(--typography-font-size-body-s);

--- a/src/components/typography/ul/ul.scss
+++ b/src/components/typography/ul/ul.scss
@@ -1,4 +1,5 @@
 .mykn-ul {
+  margin: 0;
   color: var(--typography-color-body);
   font-family: var(--typography-font-family-body);
   font-size: var(--typography-font-size-body-s);


### PR DESCRIPTION
- Grid Gutter changed according to design
- Ui/li removed margin
- Border added as an option on `Card`
- `Sidebar` button is now squared, according to design
- `Card` now is more flexible accepting any div attributes and optional className extension
- `Card` header is now a `H2` rather than a `H3`, according to design 

Changes made to fit to requirements of https://github.com/maykinmedia/open-beheer/issues/116