### PR TITLE
Allow installing project as git dependency

### DIFF
--- a/bin/build-if-needed.mjs
+++ b/bin/build-if-needed.mjs
@@ -1,0 +1,9 @@
+import child_proces from "child_process";
+import fs from "fs";
+
+if (!fs.existsSync("dist")) {
+  console.log("Building package...");
+  child_proces.execSync("npm run build", {
+    stdio: "inherit",
+  });
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "rollup": "rollup -c",
     "rollup:watch": "rollup -cw",
     "build:design-tokens": "node bin/build-design-tokens.mjs",
-    "prepare": "husky install"
+    "build:if-needed": "node bin/build-if-needed.mjs",
+    "prepare": "husky install & npm run build:if-needed"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Update the prepare script to allow for easier active development with multiple libraries.

For active development, it seems wasteful to create new tags after every few changes. By extending the `prepare` script, which is run while installing a git repo as npm dependency, we ship the entire library with its build files. This eliminates the need to create new alpha tags to see the updated active development changes in a consuming project.