### PR TITLE
Allow repo name in commit message

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,10 +1,10 @@
 /**
  * @example: :sparkles: #1 - feat: implement new feature
- * @see {@link https://regexr.com/8fcbf RegExr}
+ * @see {@link https://regexr.com/8jg18 RegExr}
  * @type {RegExp}
  */
 const COMMIT_PATTERN =
-  /(:\w+\:)(?:\s+(#\d+))?\s-\s([\w\s]+)(?:\((\w+)\))?!?:\s(.+)/;
+  /(:\w+\:)(?:\s+([\w/-]*#\d+))?\s-\s([\w\s]+)(?:\((\w+)\))?!?:\s(.+)/;
 
 // We can't use commitlint type enum here due to gitmoji.
 const TYPE_ENUM = [


### PR DESCRIPTION
Allowing words and url save characters in the commit pattern. This allows us to point the commit to specific issues from other repos, like `user/repo#1`.

This becomes quite helpful with more projects using and contributing to the admin-ui library.

Commit message example: `:hammer: user/repo-name#1 - chore: Doing some hammering`