### PR TITLE
Fix github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,6 @@ concurrency:
 
 jobs:
   build:
-    name: Create 'production' build
     runs-on: ubuntu-latest
 
     steps:
@@ -63,7 +62,6 @@ jobs:
         run: npx commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
   lint:
-    name: Run linters
     runs-on: ubuntu-latest
 
     steps:
@@ -76,7 +74,6 @@ jobs:
         run: npm run lint
 
   test:
-    name: Run tests
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The github actions for `build`, `lint` and `test` are stuck on "Expected — Waiting for status to be reported". The reason for this appears to be the job names in ci.yaml.

Github uses the job names to connect to the github actions. Because the names are things like "Create 'production' build", that name should also be used in the Github branch protection rules. The Github branch protection rules however use the simple names `build`, `test` and `lint`. Because these names don't match, github doesn't know which jobs to execute.

By removing the job names github should look at the job ids, which do match with the Github branch protection rules.

TLDR; The job names in `ci.yaml` and the Github branch protection rules don't match, which might be the reason why these actions aren't performed. By renaming the jobs the github actions should again be picked-up.