### PR TITLE
:bug: - fix: fixed edge case wherein the button inside of a select/dr…

### DIFF
--- a/src/components/toolbar/toolbar.scss
+++ b/src/components/toolbar/toolbar.scss
@@ -237,19 +237,13 @@
 
     .mykn-a,
     .mykn-accordion,
-    .mykn-button,
+    .mykn-button:not(.mykn-select .mykn-button),
     .mykn-dropdown,
     .mykn-form-control,
     .mykn-input,
     .mykn-select,
     .mykn-stackctx {
       width: 100%;
-    }
-
-    // Prevent nested buttons inside selects or dropdowns from stretching
-    > .mykn-select .mykn-button,
-    > .mykn-dropdown .mykn-button {
-      width: auto;
     }
 
     .mykn-iconinitials {


### PR DESCRIPTION
…opdown could receive `width: 100%` as a child of `toolbar`