### PR TITLE
Issue/#302 datagrid 2

### DIFF
--- a/src/components/data/datagrid/datagrid.scss
+++ b/src/components/data/datagrid/datagrid.scss
@@ -64,6 +64,14 @@
     top: var(--mykn-datagrid-thead-top-base, 0px);
   }
 
+  &__tbody &__row:nth-child(even) {
+    background-color: var(--datagrid-background-even);
+  }
+
+  &__tbody &__row:nth-child(odd) {
+    background-color: var(--datagrid-background-odd);
+  }
+
   &__thead &__row--filter {
     background-color: var(--datagrid-header-background);
 
@@ -93,8 +101,6 @@
   }
 
   &__cell {
-    border-block-start: 1px solid transparent;
-    border-block-end: 1px solid var(--datagrid-border);
     box-sizing: border-box;
     padding: var(--mykn-datagrid-spacing-v) var(--mykn-datagrid-spacing-h);
     position: relative;

--- a/src/components/data/datagrid/datagrid.tsx
+++ b/src/components/data/datagrid/datagrid.tsx
@@ -273,7 +273,7 @@ export const DataGrid = <T extends object = object, F extends object = T>(
   // Specify the default props.
   const defaults: Partial<DataGridProps<T, F>> = {
     allowOverflowX: true,
-    compact: true,
+    compact: false,
     showPaginator: Boolean(props.paginatorProps),
     selectable: false,
     allowSelectAll: true,

--- a/src/design-tokens/compiled/vars.css
+++ b/src/design-tokens/compiled/vars.css
@@ -225,7 +225,9 @@
   --button-success-disabled-shadow: var(--theme-base-foreground);
   --card-background: var(--theme-base-background);
   --datagrid-background: var(--theme-base-background);
-  --datagrid-header-background: var(--theme-base-background-alternate);
+  --datagrid-background-even: var(--theme-base-background);
+  --datagrid-background-odd: var(--theme-base-background-alternate);
+  --datagrid-header-background: var(--theme-base-background);
   --datagrid-row-active: var(--theme-brand-accent-active);
   --dropdown-border: var(--theme-brand-primary-default);
   --form-border: var(--theme-base-border);


### PR DESCRIPTION
The DataGrid's spacing is only in line with the design when `compact: false`, therefore, default should also be false

I am not sure if this is smart in terms of backward-compatibility, give me your thoughts @svenvandescheur 