### PR TITLE
:art: #302 - feat: default compact false, according to design

### DIFF
--- a/src/components/data/datagrid/datagrid.tsx
+++ b/src/components/data/datagrid/datagrid.tsx
@@ -273,7 +273,7 @@ export const DataGrid = <T extends object = object, F extends object = T>(
   // Specify the default props.
   const defaults: Partial<DataGridProps<T, F>> = {
     allowOverflowX: true,
-    compact: true,
+    compact: false,
     showPaginator: Boolean(props.paginatorProps),
     selectable: false,
     allowSelectAll: true,


### PR DESCRIPTION


The DataGrid's spacing is only in line with the design when compact: false, therefore, default should also be false

I am not sure if this is smart in terms of backward-compatibility, give me your thoughts @svenvandescheur 