### PR TITLE
Allow custom classnames on Label component

### DIFF
--- a/src/components/form/label/label.tsx
+++ b/src/components/form/label/label.tsx
@@ -11,19 +11,25 @@ export type LabelProps = React.ComponentProps<"label"> & {
 /**
  * Label component
  * @param bold
+ * @param className
  * @param children
  * @param props
  * @constructor
  */
 export const Label: React.FC<LabelProps> = ({
   bold = true,
+  className,
   children,
   ...props
 }) => (
   <label
-    className={clsx("mykn-label", {
-      "mykn-label--bold": bold,
-    })}
+    className={clsx(
+      "mykn-label",
+      {
+        "mykn-label--bold": bold,
+      },
+      className,
+    )}
     {...props}
   >
     {children}


### PR DESCRIPTION
Closes #306 

When passing a className to the Label component it should be used in addition to the component defined className.